### PR TITLE
feat(setup): add entry point so 'mls' works

### DIFF
--- a/mlsysops-cli/README.md
+++ b/mlsysops-cli/README.md
@@ -1,37 +1,72 @@
-# MLSysOps CLI
+# MLSysOps CLI (`mls`)
+<p align="center">
+  <img alt="License" src="https://img.shields.io/badge/license-MLSysOps-blue?style=for-the-badge">
+  <img alt="Python Version" src="https://img.shields.io/badge/python-3.7+-yellowgreen?style=for-the-badge&logo=python">
+  <img alt="PyPI" src="https://img.shields.io/pypi/v/mlsysops-cli?style=for-the-badge&logo=pypi">
+</p>
 
-**MLSysOps CLI** (`mls`) is a command-line tool for interacting 
-with the MLSysOps framework. It allows users to manage applications,
-infrastructure resources, and orchestration agents across the 
-device-edge-cloud continuum.
+The official command-line interface for the **MLSysOps Framework**. This tool empowers you to manage applications, infrastructure resources, and orchestration agents seamlessly across the device-edge-cloud continuum.
 
+## 📋 Table of Contents
+
+- [✨ Features](#-features)
+- [✅ Prerequisites](#-prerequisites)
+- [📦 Installation](#-installation)
+- [🔧 Configuration](#-configuration)
+- [🚀 Quick Start](#-usage)
+- [📚 Command Reference](#-command-reference)
+  - [Application Commands](#-application-commands)
+  - [Infrastructure Commands](#️-infrastructure-commands)
+  - [Management Commands](#️-management-commands)
+  - [Framework Commands](#-framework-commands)
+- [💡 Pro Tip: Enable Tab Completion](#-pro-tip-enable-tab-completion)
+- [📄 License](#-license)
+
+---
+
+## ✨ Features
+
+- **📱 Application Management**: Deploy, list, and remove applications with simple commands.
+- **🏗️ Infrastructure Insight**: Query and register infrastructure components like clusters and nodes.
+- **⚙️ System Control**: Ping system agents and switch operational modes Heuristic or ML.
+- **🤖 Agent Deployment**: Easily deploy orchestration agents to nodes, clusters, or an entire continuum.
+- **🌐 Framework installation**: Install the required components of the Framework.
+
+---
+## ✅ Prerequisites
+
+Before you begin, ensure you have the following installed:
+- **Python 3.7+**
+- `pip` (Python package installer)
+
+---
 
 ## 📦 Installation
 
-Make sure you have **Python 3.7+** and `pip` installed.
+You can install the MLSysOps CLI using one of the following methods.
 
-### Option 1: Install via pip (recommended)
+### Option 1: Install from PyPI (Recommended)
 
 ```bash
-pip install -i https://test.pypi.org/simple/ mlsysops-cli
+pip install mlsysops-cli
 ```
 
 After installation, you can use the `mls` command directly in your terminal.
 
 ---
 
-### Option 2: Install from source (for development)
+### Option 2: Install from source (For Development)
 
-If you want to work on the CLI or customize it:
+If you plan to contribute to the CLI or need the latest unreleased features, install it from the source repository.
 
 ```bash
-# Clone the repository (make sure to use the CLI branch)
-git clone -b CLI https://github.com/mlsysops-eu/mlsysops-framework.git
+# 1. Clone the repository (CLI branch)
+git clone -b CLI [https://github.com/mlsysops-eu/mlsysops-framework.git](https://github.com/mlsysops-eu/mlsysops-framework.git)
 
-# Go into the CLI directory
+# 2. Navigate to the CLI directory
 cd mlsysops-framework/mlsysops-cli
 
-# Install it in editable mode
+# 3. Install in editable mode
 pip install -e .
 ```
 
@@ -56,43 +91,69 @@ export KARMADA_HOST_IP=<karmada host ip>
 
 
 ---
-## 🚀 Usage
+## 🚀 Quick Start
+
+Get an overview of all available commands and options with the --help flag.
 
 ```bash
 mls --help
 ```
 
-Each section of the system has its own command group:
+Each major component of the framework has its own command group:
 
 - `mls apps` – Manage application deployments  
 - `mls infra` – Query and register infrastructure
 - `mls manage` – System control (ping, mode switch)  
-- `mls agents` – Deploy orchestration agents  
+- `mls framework` – Deploy the core framework components.
 
 ---
+# 📚 Command Reference
 
-## 🧹 Application Commands
+### 🧹 Application Commands
 
+Manage the lifecycle of your applications 
+
+- **Deploy an application**   
 ```bash
 mls apps deploy-app --path ./my_app.yaml
+```
+- **List all running applications**   
+```bash
 mls apps list-all
-mls apps remove-app
+```
+- **Remove an application**   
+```bash
+mls apps remove-app <application-id>
 ```
 
-## 🏗️ Infrastructure Commands
 
+
+
+
+### 🏗️ Infrastructure Commands
+Query information about your registered infrastructure.
+- **List Infrastructure by type (e.g., Cluster, Node)**  
 ```bash
 mls infra list-infra --type Cluster
 ```
 
-## ⚙️ Management Commands
+### ⚙️ Management Commands
+Perform system-level administrative tasks.
+
+-**Ping a system agent to check its status:**
 
 ```bash
 mls manage ping-agent
+```
+-**Set the system's operational mode:**
+0 for Heuristic 1 for ML
+```bash
 mls manage set-mode --mode 1
 ```
 
-## Framework Commands
+### 🌐 Framework Commands
+
+Deploy core components of the MLSysOps framework and orchestration agents.
 
 ```bash
 mls framework deploy-all
@@ -116,25 +177,22 @@ mls framework deploy-services
 > **Note:** Only one of `--path` or `--inventory` can be specified at a time. If both options are provided, the command will throw an error.
 ---
 
-## ⚡ Tab Completion (Bash)
+## 💡 Pro Tip: Enable Tab Completion
 
 Enable tab-completion for the `mls` CLI in your terminal to quickly discover available commands and options:
-
+This will help you auto-complete commands and options by simply pressing the [TAB] key.
 
 ```bash
 echo 'eval "$(_MLS_COMPLETE=bash_source mls)"' >> ~/.bashrc
 source ~/.bashrc
 ```
 
-Then try:
-
-```bash
-mls [TAB][TAB]
-```
-Enjoy instant access to commands and flags 🎉
+Now you can type mls [TAB][TAB] to see all available commands. It's a game-changer! 🎉
 
 ---
 
 ## 📄 License
 
-License © 2025 [MLSysOps]
+This project is licensed by MLSysOps.
+
+## Copyright © 2025 MLSysOps.

--- a/mlsysops-cli/setup.py
+++ b/mlsysops-cli/setup.py
@@ -24,6 +24,11 @@ setup(
     package_data={
         "mlsysops_cli": ["templates/*.j2","deployment/*/*.yaml"],
     },
+    entry_points={
+        "console_scripts": [
+            "mls = mlsysops_cli.cli:cli",
+        ],
+    },
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
add entry point in the setup.py file so 'mls' works after installation. 
reason: after doing pip install 'mls' command was not recognizable 
Test: Install the package and after installation run 'mls' it may show the CLI available comands 